### PR TITLE
Tell npm 1.2.24 to install

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "mocha": "0.11.x"
     },
     "scripts": {
-        "test": "mocha -R spec"
+        "test": "mocha -R spec",
+        "install": "node-waf configure build"
     }
 }


### PR DESCRIPTION
Gets this building on node 0.8.24.  Npm 1.2.24 (bundled with node 0.8.24) doesn't run wscripts automatically, so this tells npm to install.  Ideally, we'll just use gyp when we go to node 0.10.x.

This is tested with both node 0.8.22 and 0.8.24.  `npm install` and `npm test` were happy for both.
