### PR TITLE
Test fixtures require at least node-mapnik@3.1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: node_js
 
 node_js:
-  - "0.10.33"
+  - "0.10"
+  - "0.12"
+
+sudo:false
 
 before_install:
-- sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-- sudo apt-get update -q
-- sudo apt-get install -y libstdc++6
+# install c++11 capable libstdc++ without sudo
+- if [[ $(uname -s) == 'Linux' ]]; then wget https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test/+files/libstdc%2B%2B6_4.8.1-2ubuntu1~12.04_amd64.deb && dpkg -x libstdc++6_4.8.1-2ubuntu1~12.04_amd64.deb ./ && export LD_PRELOAD=$(pwd)/usr/lib/x86_64-linux-gnu/libstdc++.so.6; fi
 
 install:
 - npm install --loglevel=http

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - "0.10"
   - "0.12"
 
-sudo:false
+sudo: false
 
 before_install:
 # install c++11 capable libstdc++ without sudo

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "rimraf": "~2.2.8"
     },
     "dependencies" : {
-        "mapnik": "3.x"
+        "mapnik": "~3.1.5"
     },
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
The update for node-mapnik 3.1.5 already landed in master (https://github.com/mapbox/node-blend/commit/cfedbf92c11a9f863de08224605513e99f3d9e21). In the future we'll keep these to branches/pull requests.

Once this is green next steps are to:

  - [ ] merge
  - [ ] publish new release
