### PR TITLE
Bump Mapnik version to 3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "rimraf": "~2.2.8"
     },
     "dependencies" : {
-        "mapnik": "~3.2.0"
+        "mapnik": "~3.4.0"
     },
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
[makizushi is build failing](https://travis-ci.org/mapbox/makizushi/builds/74344252) because `assert-http` has `mapnik 3.4.2` as a dependency and `blend` has `mapnik 3.2.0` as a dependency. This PR updates the `package.json` for this module to `"mapnik": "~3.4.0"`. I'm not familiar with this module, so I don't know what else needs to be changed for this to work, and I'm not sure if changing the mapnik version requires a version bump for `blend`, and really I'm not sure about much of anything here because this is all new to me.

@springmeyer I would love your thoughts and expertise here! :blush: 