### PR TITLE
Bump to 1.3.0, Updated to mapnik 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changlog
 
+## 1.3.0
+
+- Updated to mapnik 3.6.0
+
 ## 1.2.0
 
 - Updated to mapnik 3.5.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,9 @@ os: Visual Studio 2015
 environment:
   matrix:
     - nodejs_version: 0.10.40
+      msvs_toolset: 14
     - nodejs_version: 0.12.7
+      msvs_toolset: 14
 
 platform:
   - x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,6 @@ os: Visual Studio 2015
 environment:
   matrix:
     - nodejs_version: 0.10.40
-      msvs_toolset: 14
-    - nodejs_version: 0.12.7
-      msvs_toolset: 14
 
 platform:
   - x64

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "blend",
+  "name": "@mapbox/blend",
   "description": "High speed image blending and quantization",
   "version": "1.3.0",
   "homepage": "http://github.com/mapbox/node-blend",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blend",
   "description": "High speed image blending and quantization",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "homepage": "http://github.com/mapbox/node-blend",
   "author": "Konstantin Käfer <kkaefer@gmail.com>",
   "repository": {
@@ -25,7 +25,7 @@
     "eslint-config-unstyled": "^1.1.0"
   },
   "dependencies": {
-    "mapnik": "~3.5.0"
+    "mapnik": "~3.6.0"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
/cc @springmeyer for review

Due to change in namespace after merge:

- [ ] Run `npm publish --access=public` to publish the first namespaced version
- [ ] Run `npm deprecate blend "This module has moved: please install @mapbox/blend instead"`